### PR TITLE
Implement optional permissions

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -197,11 +197,15 @@ grunt.registerTask('set_version', (version) => {
 function processManifestTemplate(content) {
     let manifest = JSON.parse(content);
     function processObj(obj) {
+        if (Array.isArray(obj)) {
+            let index = obj.indexOf('<%= all_google_maps_urls %>');
+            if (index !== -1) {
+                obj.splice(index, 1, ...getGoogleMapUrls());
+            }
+        }
         if (typeof obj === 'object') {
-            for (o in obj) {
-                if (obj[o] === '<%= all_google_maps_urls %>') {
-                    obj[o] = getGoogleMapUrls();
-                } else if (typeof obj[o] === 'object') {
+            for (let o in obj) {
+                if (typeof obj[o] === 'object') {
                     processObj(obj[o]);
                 }
             }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -275,7 +275,8 @@ const TEST_SITES = [
     'https://www.google.com/maps/d/viewer?mid=1ZpcZ8OMZh1G1XwRmt9GaCwH6f-g&amp%3Bhl=en',
     'https://www.geckoboard.com/tech-acquisitions/',
     'http://thecopperonion.com/location',
-    'http://la.smorgasburg.com/info/'
+    'http://la.smorgasburg.com/info/',
+    'https://www.heywhatsthat.com/?view=P5XIGCII'
 ];
 
 const MAPBOX_TEST_SITES = [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -157,6 +157,7 @@ grunt.registerMultiTask('open', function() {
 grunt.registerTask('build', [
     'uglify:all',
     'concat:all',
+    'generate_domains',
     'copy:all',
     'copy:manifest',
     'newer:imagemin']);
@@ -190,6 +191,14 @@ grunt.registerTask('set_version', (version) => {
     if (!version) grunt.fatal(`Invalid version "${version}"`);
     grunt.config.set('pluginDir', `gen/plugin-${version}`);
     grunt.config.set('version', version);
+});
+
+grunt.registerTask('generate_domains', () => {
+    let urls = getGoogleMapUrls();
+    let pluginDir = grunt.config.get('pluginDir');
+    grunt.file.write(
+        `${pluginDir}/src/domains.js`,
+        'const SCROLLMAPS_DOMAINS = ' + JSON.stringify(urls));
 });
 
 // ========== Generate manifest ========== //

--- a/manifest_template.json
+++ b/manifest_template.json
@@ -28,6 +28,7 @@
     "images/button_inactive.png",
     "inject_content.min.js"
   ],
+  "content_security_policy": "script-src 'self' https://maps.googleapis.com https://maps.gstatic.com; object-src 'self'",
   "options_page": "src/options/options.html",
   "icons": {
     "16": "images/maps_16.png",

--- a/manifest_template.json
+++ b/manifest_template.json
@@ -6,7 +6,7 @@
   "description": "Allow you to use two finger scroll on your Mac trackpad in Google Maps.",
   "content_scripts": [
     {
-      "matches": "<%= all_google_maps_urls %>",
+      "matches": ["<%= all_google_maps_urls %>"],
       "js": ["inject_frame.min.js"],
       "all_frames": true,
       "run_at": "document_start"
@@ -17,6 +17,7 @@
       "src/jquery.js",
       "src/Shim.js",
       "src/pref.js",
+      "src/permission.js",
       "src/background.js"
     ],
     "persistent": true
@@ -39,7 +40,8 @@
     "webRequest",
     "tabs",
     "*://maps.google.com/",
-    "*://www.google.com/maps/"
+    "*://www.google.com/maps/",
+    "<%= all_google_maps_urls %>"
   ],
   "optional_permissions": [
     "<all_urls>"

--- a/manifest_template.json
+++ b/manifest_template.json
@@ -17,6 +17,7 @@
       "src/jquery.js",
       "src/Shim.js",
       "src/pref.js",
+      "src/domains.js",
       "src/permission.js",
       "src/background.js"
     ],

--- a/manifest_template.json
+++ b/manifest_template.json
@@ -40,6 +40,7 @@
     "activeTab",
     "webRequest",
     "tabs",
+    "*://maps.googleapis.com/*",
     "*://maps.google.com/",
     "*://www.google.com/maps/",
     "<%= all_google_maps_urls %>"

--- a/manifest_template.json
+++ b/manifest_template.json
@@ -32,6 +32,7 @@
     "48": "images/maps_48.png",
     "128": "images/maps_128.png"
   },
+  "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC3XeoaqQRtfyt5UOKmdyeGm6ynNFixgxA6+L49HQCm9SffiesKkWh14JrhDpydJco8rN8Eaa/mVhYctZzjQK8LlUjceUrPY3pWAIooQFC94ELrTh5JfwaUd5g/2LOSpH22nUdpEEQ/ffiQOhGSwPaAwavXjNpK3QYRDEz8+RG7EQIDAQAB",
   "permissions": [
     "webRequest",
     "tabs",

--- a/manifest_template.json
+++ b/manifest_template.json
@@ -33,11 +33,15 @@
     "128": "images/maps_128.png"
   },
   "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC3XeoaqQRtfyt5UOKmdyeGm6ynNFixgxA6+L49HQCm9SffiesKkWh14JrhDpydJco8rN8Eaa/mVhYctZzjQK8LlUjceUrPY3pWAIooQFC94ELrTh5JfwaUd5g/2LOSpH22nUdpEEQ/ffiQOhGSwPaAwavXjNpK3QYRDEz8+RG7EQIDAQAB",
+  "browser_action": {},
   "permissions": [
+    "activeTab",
     "webRequest",
     "tabs",
     "*://maps.google.com/",
-    "*://www.google.com/maps/",
+    "*://www.google.com/maps/"
+  ],
+  "optional_permissions": [
     "<all_urls>"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,19 +40,6 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
-    "ajv": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      }
-    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -116,12 +103,20 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.11"
+            "lodash": "^4.17.14"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "4.17.15",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+              "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+              "dev": true
+            }
           }
         }
       }
@@ -211,23 +206,6 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true,
-      "optional": true
-    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -240,32 +218,11 @@
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true,
-      "optional": true
-    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true,
-      "optional": true
-    },
-    "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-      "dev": true,
-      "optional": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -333,16 +290,6 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
       "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
       "dev": true
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "bin-build": {
       "version": "3.0.0",
@@ -603,16 +550,6 @@
         "readable-stream": "^2.0.5"
       }
     },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "inherits": "~2.0.0"
-      }
-    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -766,13 +703,6 @@
         "map-obj": "^1.0.0"
       }
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true,
-      "optional": true
-    },
     "caw": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
@@ -800,9 +730,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
       "dev": true,
       "optional": true
     },
@@ -928,16 +858,6 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
     },
     "commander": {
       "version": "2.19.0",
@@ -1161,16 +1081,6 @@
         "array-find-index": "^1.0.1"
       }
     },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "dateformat": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
@@ -1385,13 +1295,6 @@
         }
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
-      "optional": true
-    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -1400,9 +1303,9 @@
       "optional": true
     },
     "detect-libc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-0.2.0.tgz",
-      "integrity": "sha1-R/31ZzSKF+wl/L8LnkRjSKdvn7U=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "dev": true,
       "optional": true
     },
@@ -1516,17 +1419,6 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true,
       "optional": true
-    },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -1717,9 +1609,9 @@
       }
     },
     "expand-template": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
-      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "dev": true,
       "optional": true
     },
@@ -1830,20 +1722,6 @@
         }
       }
     },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true,
-      "optional": true
-    },
-    "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true,
-      "optional": true
-    },
     "fast-glob": {
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
@@ -1857,13 +1735,6 @@
         "merge2": "^1.2.3",
         "micromatch": "^3.1.10"
       }
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true,
-      "optional": true
     },
     "fd-slicer": {
       "version": "1.1.0",
@@ -1999,25 +1870,6 @@
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true,
-      "optional": true
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -2038,24 +1890,18 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "optional": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -2115,16 +1961,6 @@
       "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
       "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
       "dev": true
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
     },
     "gifsicle": {
       "version": "4.0.1",
@@ -2384,14 +2220,14 @@
       }
     },
     "grunt-contrib-compress": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-1.5.0.tgz",
-      "integrity": "sha512-RcCyetnvTJ7jvnDCSm05wOndAd00HWZTHeVGDVVmCM+K/PEivL0yx8vKyi8uzy0492l2dJgtzR0Ucid7roKg6A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-1.6.0.tgz",
+      "integrity": "sha512-wIFuvk+/Ny4E+OgEfJYFZgoH7KcU/nnNFbYasB7gRvrcRyW6vmTp3Pj8a4rFSR3tbFMjrGvTUszdO6fgLajgZQ==",
       "dev": true,
       "requires": {
         "archiver": "^1.3.0",
         "chalk": "^1.1.1",
-        "iltorb": "^1.3.10",
+        "iltorb": "^2.4.3",
         "lodash": "^4.7.0",
         "pretty-bytes": "^4.0.2",
         "stream-buffers": "^2.1.0"
@@ -2691,24 +2527,6 @@
         "duplexer": "^0.1.1"
       }
     },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true,
-      "optional": true
-    },
-    "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      }
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -2829,18 +2647,6 @@
       "dev": true,
       "optional": true
     },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      }
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -2863,16 +2669,17 @@
       "dev": true
     },
     "iltorb": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/iltorb/-/iltorb-1.3.10.tgz",
-      "integrity": "sha512-nyB4+ru1u8CQqQ6w7YjasboKN3NQTN8GH/V/eEssNRKhW6UbdxdWhB9fJ5EEdjJfezKY0qPrcwLyIcgjL8hHxA==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/iltorb/-/iltorb-2.4.4.tgz",
+      "integrity": "sha512-7Qk6O7TK3rSWVRVRkPehcNTSN+P2i7MsG9pWmw6iVw/W6NcoNj0rFKOuBDM6fbZV6NNGuUW3JBRem6Ozn4KXhg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "detect-libc": "^0.2.0",
-        "nan": "^2.6.2",
-        "node-gyp": "^3.6.2",
-        "prebuild-install": "^2.3.0"
+        "detect-libc": "^1.0.3",
+        "nan": "^2.14.0",
+        "npmlog": "^4.1.2",
+        "prebuild-install": "^5.3.2",
+        "which-pm-runs": "^1.0.0"
       }
     },
     "imagemin": {
@@ -3252,13 +3059,6 @@
         "has-symbols": "^1.0.0"
       }
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true,
-      "optional": true
-    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -3294,13 +3094,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true,
-      "optional": true
     },
     "isurl": {
       "version": "1.0.0",
@@ -3343,53 +3136,12 @@
         }
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
-      "optional": true
-    },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true,
       "optional": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true,
-      "optional": true
-    },
-    "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "optional": true
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true,
-      "optional": true
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
     },
     "keyv": {
       "version": "3.0.0",
@@ -3430,9 +3182,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "logalot": {
@@ -3603,16 +3355,6 @@
       "dev": true,
       "optional": true
     },
-    "mime-types": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "mime-db": "1.40.0"
-      }
-    },
     "mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
@@ -3636,9 +3378,9 @@
       "dev": true
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -3755,6 +3497,13 @@
         "to-regex": "^3.0.1"
       }
     },
+    "napi-build-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
+      "integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA==",
+      "dev": true,
+      "optional": true
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -3763,43 +3512,13 @@
       "optional": true
     },
     "node-abi": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.8.0.tgz",
-      "integrity": "sha512-1/aa2clS0pue0HjckL62CsbhWWU35HARvBDXcJtYKbYR7LnIutmpxmXbuDMV9kEviD2lP/wACOgWmmwljghHyQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.13.0.tgz",
+      "integrity": "sha512-9HrZGFVTR5SOu3PZAnAY2hLO36aW1wmA+FDsVkr85BTST32TLCA1H/AEcatVRAsWLyXS3bqUDYCAjq5/QGuSTA==",
       "dev": true,
       "optional": true,
       "requires": {
         "semver": "^5.4.1"
-      }
-    },
-    "node-gyp": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
-      "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "fstream": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3 || 4",
-        "osenv": "0",
-        "request": "^2.87.0",
-        "rimraf": "2",
-        "semver": "~5.3.0",
-        "tar": "^2.0.0",
-        "which": "1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "noop-logger": {
@@ -3929,13 +3648,6 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true,
-      "optional": true
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4032,9 +3744,9 @@
       }
     },
     "open": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-6.3.0.tgz",
-      "integrity": "sha512-6AHdrJxPvAXIowO/aIaeHZ8CeMdDf7qCyRNq8NwJpinmCdXhz+NZR7ie1Too94lpciCDsG+qHGO9Mt0svA4OqA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
@@ -4060,31 +3772,6 @@
       "optional": true,
       "requires": {
         "arch": "^2.1.0"
-      }
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true,
-      "optional": true
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true,
-      "optional": true
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
       }
     },
     "p-cancelable": {
@@ -4224,13 +3911,6 @@
       "dev": true,
       "optional": true
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true,
-      "optional": true
-    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -4268,36 +3948,27 @@
       "dev": true
     },
     "prebuild-install": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
-      "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.3.tgz",
+      "integrity": "sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==",
       "dev": true,
       "optional": true,
       "requires": {
         "detect-libc": "^1.0.3",
-        "expand-template": "^1.0.2",
+        "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
         "minimist": "^1.2.0",
         "mkdirp": "^0.5.1",
-        "node-abi": "^2.2.0",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
         "noop-logger": "^0.1.1",
         "npmlog": "^4.0.1",
-        "os-homedir": "^1.0.1",
-        "pump": "^2.0.1",
-        "rc": "^1.1.6",
-        "simple-get": "^2.7.0",
-        "tar-fs": "^1.13.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^3.0.3",
+        "tar-fs": "^2.0.0",
         "tunnel-agent": "^0.6.0",
         "which-pm-runs": "^1.0.0"
-      },
-      "dependencies": {
-        "detect-libc": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "prepend-http": {
@@ -4336,17 +4007,10 @@
       "dev": true,
       "optional": true
     },
-    "psl": {
-      "version": "1.1.32",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
-      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==",
-      "dev": true,
-      "optional": true
-    },
     "pump": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4354,24 +4018,10 @@
         "once": "^1.3.1"
       }
     },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
-      "optional": true
-    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-      "dev": true,
-      "optional": true
-    },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true,
       "optional": true
     },
@@ -4489,58 +4139,6 @@
       "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
       "dev": true
     },
-    "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "extend": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-          "dev": true,
-          "optional": true
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "resolve": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
@@ -4568,13 +4166,6 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
-    },
-    "rimraf": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-      "dev": true,
-      "optional": true
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -4657,9 +4248,9 @@
       "optional": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -4710,15 +4301,34 @@
       "optional": true
     },
     "simple-get": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "decompress-response": "^3.3.0",
+        "decompress-response": "^4.2.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      },
+      "dependencies": {
+        "decompress-response": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "mimic-response": "^2.0.0"
+          }
+        },
+        "mimic-response": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz",
+          "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "slash": {
@@ -4942,24 +4552,6 @@
         "lpad-align": "^1.0.1"
       }
     },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
-    },
     "stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
@@ -5146,40 +4738,70 @@
         }
       }
     },
-    "tar": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.12",
-        "inherits": "2"
-      }
-    },
     "tar-fs": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
+      "integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "chownr": "^1.0.1",
+        "chownr": "^1.1.1",
         "mkdirp": "^0.5.1",
-        "pump": "^1.0.0",
-        "tar-stream": "^1.1.2"
+        "pump": "^3.0.0",
+        "tar-stream": "^2.0.0"
       },
       "dependencies": {
-        "pump": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+        "bl": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+          "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
           "dev": true,
           "optional": true,
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "readable-stream": "^3.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "dev": true,
+          "optional": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        },
+        "tar-stream": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
+          "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bl": "^3.0.0",
+            "end-of-stream": "^1.4.1",
+            "fs-constants": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1"
           }
         }
       }
@@ -5270,26 +4892,6 @@
         "repeat-string": "^1.6.1"
       }
     },
-    "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -5315,13 +4917,6 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
-      "optional": true
     },
     "typedarray": {
       "version": "0.0.6",
@@ -5361,38 +4956,15 @@
       }
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unquote": {
@@ -5440,16 +5012,6 @@
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         }
-      }
-    },
-    "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "punycode": "^2.1.0"
       }
     },
     "uri-path": {
@@ -5519,18 +5081,6 @@
       "requires": {
         "spdx-correct": "~1.0.0",
         "spdx-expression-parse": "~1.0.0"
-      }
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "walkdir": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {},
   "devDependencies": {
     "grunt": "^1.0.4",
-    "grunt-contrib-compress": "^1.5.0",
+    "grunt-contrib-compress": "^1.6.0",
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-imagemin": "^3.1.0",
@@ -31,6 +31,6 @@
     "grunt-mocha-test": "^0.13.3",
     "grunt-newer": "^1.3.0",
     "mocha": "^5.2.0",
-    "open": "^6.3.0"
+    "open": "^6.4.0"
   }
 }

--- a/scrollmaps.sublime-workspace
+++ b/scrollmaps.sublime-workspace
@@ -4,6 +4,50 @@
 		"selected_items":
 		[
 			[
+				"refre",
+				"refreshScrollMapsStatus"
+			],
+			[
+				"BAD",
+				"BADGE_ACTIVE"
+			],
+			[
+				"bad",
+				"badgeText"
+			],
+			[
+				"ba",
+				"badge2"
+			],
+			[
+				"get",
+				"getBadgeText"
+			],
+			[
+				"up",
+				"updateBrowserAction"
+			],
+			[
+				"prot",
+				"protocol"
+			],
+			[
+				"box",
+				"box-content"
+			],
+			[
+				"remove",
+				"removeOrigins"
+			],
+			[
+				"site",
+				"isSiteGranted"
+			],
+			[
+				"is",
+				"isSiteGranted"
+			],
+			[
 				"al",
 				"alreadySet"
 			],
@@ -431,10 +475,81 @@
 	},
 	"buffers":
 	[
+		{
+			"file": "src/background.js",
+			"settings":
+			{
+				"buffer_size": 4807,
+				"encoding": "UTF-8",
+				"line_ending": "Unix"
+			}
+		},
+		{
+			"file": "src/options/options.html",
+			"settings":
+			{
+				"buffer_size": 1222,
+				"line_ending": "Unix"
+			}
+		},
+		{
+			"file": "src/options/options.js",
+			"settings":
+			{
+				"buffer_size": 2235,
+				"encoding": "UTF-8",
+				"line_ending": "Unix"
+			}
+		},
+		{
+			"file": "src/inject_content.js",
+			"settings":
+			{
+				"buffer_size": 7469,
+				"line_ending": "Unix"
+			}
+		},
+		{
+			"file": "src/mapapi_inject.js",
+			"settings":
+			{
+				"buffer_size": 3866,
+				"encoding": "UTF-8",
+				"line_ending": "Unix"
+			}
+		},
+		{
+			"file": "src/inject_frame.js",
+			"settings":
+			{
+				"buffer_size": 884,
+				"line_ending": "Unix"
+			}
+		}
 	],
-	"build_system": "",
+	"build_system": "Packages/User/grunt.sublime-build",
 	"build_system_choices":
 	[
+		[
+			[
+				[
+					"Packages/Makefile/Make.sublime-build",
+					""
+				],
+				[
+					"Packages/Makefile/Make.sublime-build",
+					"Clean"
+				],
+				[
+					"Packages/User/grunt.sublime-build",
+					""
+				]
+			],
+			[
+				"Packages/User/grunt.sublime-build",
+				""
+			]
+		]
 	],
 	"build_varint": "",
 	"command_palette":
@@ -581,20 +696,41 @@
 	},
 	"expanded_folders":
 	[
-		"/Users/mauricelam/Desktop/Maurice/code/maps"
+		"/Users/mauricelam/Desktop/Maurice/code/maps",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/options",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/popup",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/test"
 	],
 	"file_history":
 	[
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/inject_content.js",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/ScrollableMap.js",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/manifest_template.json",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/inject_frame.js",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/background.js",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/options/options.js",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/options/options.html",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/gen/plugin-10000/inject_frame.min.js",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/options/options.css",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/Shim.js",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/pref.js",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/popup/popup.js",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/prefmaker.js",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/prefreader.js",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/permission.js",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/popup/popup.html",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/package.json",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/Gruntfile.js",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/gen/plugin-10000/src/domains.js",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/gen/plugin-10000/manifest.json",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/popup/popup.css",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/popup/permission.js",
+		"/Users/mauricelam/Desktop/Maurice/code/maps/src/mapapi_inject.js",
+		"/Users/mauricelam/Desktop/Maurice/code/hashbang/TODO",
 		"/Users/mauricelam/Library/Application Support/Sublime Text 3/Packages/User/Preferences.sublime-settings",
 		"/Users/mauricelam/Library/Application Support/Sublime Text 3/Packages/Default/Preferences.sublime-settings",
-		"/Users/mauricelam/Desktop/Maurice/code/maps/Gruntfile.js",
 		"/Users/mauricelam/Desktop/Maurice/code/maps/gen/plugin-10000/mapapi_inject.min.js",
-		"/Users/mauricelam/Desktop/Maurice/code/maps/src/inject_content.js",
-		"/Users/mauricelam/Desktop/Maurice/code/maps/manifest_template.json",
-		"/Users/mauricelam/Desktop/Maurice/code/maps/src/background.js",
-		"/Users/mauricelam/Desktop/Maurice/code/maps/src/ScrollableMap.js",
-		"/Users/mauricelam/Desktop/Maurice/code/maps/src/mapapi_inject.js",
-		"/Users/mauricelam/Desktop/Maurice/code/maps/package.json",
 		"/Users/mauricelam/Desktop/Maurice/code/maps/src/api_inject.js",
 		"/Users/mauricelam/Desktop/Maurice/code/maps/src/empty.js",
 		"/Users/mauricelam/.gitconfig",
@@ -602,7 +738,6 @@
 		"/Users/mauricelam/Desktop/Maurice/code/hashbang/setup.py",
 		"/Users/mauricelam/Desktop/Maurice/code/hashbang/pypi.py",
 		"/Users/mauricelam/Desktop/Maurice/code/hashbang/hashbang/hashbang.py",
-		"/Users/mauricelam/Desktop/Maurice/code/hashbang/TODO",
 		"/Users/mauricelam/Desktop/Maurice/code/hashbang/tests/extension/remainder.py",
 		"/Users/mauricelam/Desktop/Maurice/code/hashbang/tests/basic/trailing_underscore.py",
 		"/Users/mauricelam/Desktop/Maurice/code/hashbang/tests/extension/version.py",
@@ -696,33 +831,18 @@
 		"/Users/mauricelam/go/src/github.com/mauricelam/genny/parse/test/multipletypes/interface_int_simplemap.go",
 		"/Users/mauricelam/go/src/github.com/mauricelam/genny/parse/typesets_test.go",
 		"/Users/mauricelam/go/src/github.com/mauricelam/genny/parse/test/buildtags/buildtags_expected_multiple.go",
-		"/Users/mauricelam/go/src/github.com/mauricelam/genny/main.go",
-		"/Users/mauricelam/go/src/github.com/mauricelam/genny/parse/test/buildtags/buildtags_expected_nostrip.go",
-		"/Users/mauricelam/go/src/github.com/mauricelam/genny/parse/test/buildtags/buildtags_expected.go",
-		"/Users/mauricelam/go/src/github.com/mauricelam/genny/parse/test/buildtags/buildtags.go",
-		"/Users/mauricelam/go/src/github.com/mauricelam/genny/parse/string_array_set.go",
-		"/Users/mauricelam/go/src/github.com/mauricelam/genny/parse/test/bugreports/negation_string.go",
-		"/Users/mauricelam/go/src/github.com/mauricelam/genny/parse/test/bugreports/negation_generic.go",
-		"/Users/mauricelam/go/src/github.com/mauricelam/genny/.travis.yml",
-		"/Users/mauricelam/go/src/github.com/mauricelam/genny/parse/test/interface-template/generic_expected.go",
-		"/Users/mauricelam/go/src/github.com/mauricelam/genny/parse/test/bugreports/int_digraph.go",
-		"/Users/mauricelam/go/src/github.com/mauricelam/genny/parse/test/interfaces/join_expected.go",
-		"/Users/mauricelam/go/src/github.com/mauricelam/genny/parse/test/bugreports/generic_digraph.go",
-		"/Users/mauricelam/go/src/github.com/mauricelam/genny/parse/test/interfaces/join.go",
-		"/Users/mauricelam/go/src/github.com/mauricelam/genny/examples/interfaces/join.go",
-		"/Users/mauricelam/go/src/github.com/mauricelam/genny/parse/test/bugreports/int_new_and_make_slice.go",
-		"/Users/mauricelam/go/src/github.com/mauricelam/genny/parse/test/bugreports/interface_uint8.go",
-		"/Users/mauricelam/go/src/github.com/mauricelam/genny/g.go"
+		"/Users/mauricelam/go/src/github.com/mauricelam/genny/main.go"
 	],
 	"find":
 	{
-		"height": 24.0
+		"height": 39.0
 	},
 	"find_in_files":
 	{
 		"height": 101.0,
 		"where_history":
 		[
+			""
 		]
 	},
 	"find_state":
@@ -730,6 +850,100 @@
 		"case_sensitive": false,
 		"find_history":
 		[
+			"finder",
+			"container.querySelector",
+			"injectScript",
+			"tabId",
+			"INJECT FRAME",
+			"console.log",
+			"iframe",
+			"sendMessage",
+			"key",
+			"request",
+			"isolateZoomScroll",
+			"setBrowserActionBadge",
+			"onclick",
+			" return {}",
+			"injectScript",
+			"updateAllTabs",
+			"refreshScrollMapsStatus",
+			"injectscript",
+			"inject",
+			"refresh",
+			"injectscr",
+			"execu",
+			"BADGE_LOADING",
+			"BADGE_ORDER",
+			"BADGE_NONE",
+			"onclick",
+			"BADGE_LOADING",
+			"data-scrollmaps",
+			"setBrowserActionBadge",
+			"BADGE_NONE",
+			"setbad",
+			"refreshScrollMapsStatus",
+			"updateBrowserAction",
+			"initializeTab",
+			"details.tabId",
+			"state",
+			"chrome.runtime.onMessage.addListener",
+			"message",
+			"'active",
+			"isMapsSite",
+			"tabId",
+			"tab",
+			"updateBrowserAction",
+			"initialize",
+			"updateBrowserAction",
+			"initializeTab",
+			"radio",
+			"isRequiredPermission",
+			"isrequiredper",
+			"google.com",
+			"chrome://",
+			"permission.js",
+			"copy",
+			"REQUIRED_PERMISSION_ORIGINS",
+			"REQUIRED",
+			"TODO",
+			"status.isAllGranted",
+			"*://www.google.com/maps/",
+			"getGoogleMapUrls",
+			"all_google_maps_urls",
+			"in",
+			"PMradio",
+			"this.value",
+			"site_granted",
+			"not_granted",
+			"radio",
+			"d",
+			"PMradio",
+			"fullmaps",
+			"URL",
+			"url",
+			"loadsite",
+			"ismaps",
+			"getPermissions",
+			"markTabAsActive",
+			"tabUrl",
+			"<div>",
+			"div",
+			"PMcheckbox",
+			"site_granted",
+			"result",
+			"tabUrl",
+			"site_granted",
+			"getTabUrl",
+			"checked",
+			"options",
+			"DEBUG",
+			"details.tabId",
+			"maps",
+			"data-scrollmaps",
+			"self.type",
+			"data-scrollmap",
+			"hasattribu",
+			".parentnode"
 		],
 		"highlight": true,
 		"in_selection": false,
@@ -747,14 +961,210 @@
 	"groups":
 	[
 		{
+			"selected": 5,
 			"sheets":
 			[
+				{
+					"buffer": 0,
+					"file": "src/background.js",
+					"semi_transient": false,
+					"settings":
+					{
+						"buffer_size": 4807,
+						"regions":
+						{
+						},
+						"selection":
+						[
+							[
+								1324,
+								1324
+							]
+						],
+						"settings":
+						{
+							"SL.283.region_keys":
+							[
+							],
+							"syntax": "Packages/JavaScript/JavaScript.sublime-syntax",
+							"tab_size": 4,
+							"translate_tabs_to_spaces": true
+						},
+						"translation.x": 0.0,
+						"translation.y": 132.0,
+						"zoom_level": 1.0
+					},
+					"stack_index": 3,
+					"type": "text"
+				},
+				{
+					"buffer": 1,
+					"file": "src/options/options.html",
+					"semi_transient": false,
+					"settings":
+					{
+						"buffer_size": 1222,
+						"regions":
+						{
+						},
+						"selection":
+						[
+							[
+								655,
+								655
+							]
+						],
+						"settings":
+						{
+							"syntax": "Packages/HTML/HTML.sublime-syntax",
+							"tab_size": 4,
+							"translate_tabs_to_spaces": true
+						},
+						"translation.x": 0.0,
+						"translation.y": 0.0,
+						"zoom_level": 1.0
+					},
+					"stack_index": 2,
+					"type": "text"
+				},
+				{
+					"buffer": 2,
+					"file": "src/options/options.js",
+					"semi_transient": false,
+					"settings":
+					{
+						"buffer_size": 2235,
+						"regions":
+						{
+						},
+						"selection":
+						[
+							[
+								19,
+								19
+							]
+						],
+						"settings":
+						{
+							"SL.301.region_keys":
+							[
+							],
+							"syntax": "Packages/JavaScript/JavaScript.sublime-syntax",
+							"tab_size": 4,
+							"translate_tabs_to_spaces": true
+						},
+						"translation.x": 0.0,
+						"translation.y": 0.0,
+						"zoom_level": 1.0
+					},
+					"stack_index": 4,
+					"type": "text"
+				},
+				{
+					"buffer": 3,
+					"file": "src/inject_content.js",
+					"semi_transient": false,
+					"settings":
+					{
+						"buffer_size": 7469,
+						"regions":
+						{
+						},
+						"selection":
+						[
+							[
+								0,
+								0
+							]
+						],
+						"settings":
+						{
+							"SL.295.region_keys":
+							[
+							],
+							"syntax": "Packages/JavaScript/JavaScript.sublime-syntax",
+							"tab_size": 4,
+							"translate_tabs_to_spaces": true
+						},
+						"translation.x": 0.0,
+						"translation.y": 0.0,
+						"zoom_level": 1.0
+					},
+					"stack_index": 5,
+					"type": "text"
+				},
+				{
+					"buffer": 4,
+					"file": "src/mapapi_inject.js",
+					"semi_transient": false,
+					"settings":
+					{
+						"buffer_size": 3866,
+						"regions":
+						{
+						},
+						"selection":
+						[
+							[
+								3148,
+								3148
+							]
+						],
+						"settings":
+						{
+							"SL.293.region_keys":
+							[
+							],
+							"syntax": "Packages/JavaScript/JavaScript.sublime-syntax",
+							"tab_size": 4,
+							"translate_tabs_to_spaces": true
+						},
+						"translation.x": 0.0,
+						"translation.y": 908.0,
+						"zoom_level": 1.0
+					},
+					"stack_index": 1,
+					"type": "text"
+				},
+				{
+					"buffer": 5,
+					"file": "src/inject_frame.js",
+					"semi_transient": false,
+					"settings":
+					{
+						"buffer_size": 884,
+						"regions":
+						{
+						},
+						"selection":
+						[
+							[
+								491,
+								491
+							]
+						],
+						"settings":
+						{
+							"SL.306.region_keys":
+							[
+							],
+							"syntax": "Packages/JavaScript/JavaScript.sublime-syntax",
+							"tab_size": 4,
+							"translate_tabs_to_spaces": true
+						},
+						"translation.x": 0.0,
+						"translation.y": 0.0,
+						"zoom_level": 1.0
+					},
+					"stack_index": 0,
+					"type": "text"
+				}
 			]
 		}
 	],
 	"incremental_find":
 	{
-		"height": 24.0
+		"height": 38.0
 	},
 	"input":
 	{
@@ -787,6 +1197,10 @@
 	{
 		"height": 0.0
 	},
+	"output.exec":
+	{
+		"height": 108.0
+	},
 	"output.find_results":
 	{
 		"height": 0.0
@@ -805,12 +1219,140 @@
 		"selected_items":
 		[
 			[
+				"infra",
+				"src/inject_frame.js"
+			],
+			[
+				"ophtml",
+				"src/options/options.html"
+			],
+			[
+				"options",
+				"src/options/options.js"
+			],
+			[
+				"injcon",
+				"src/inject_content.js"
+			],
+			[
 				"map",
+				"src/mapapi_inject.js"
+			],
+			[
+				"scrollmap",
+				"src/ScrollableMap.js"
+			],
+			[
+				"injecon",
+				"src/inject_content.js"
+			],
+			[
+				"back",
+				"src/background.js"
+			],
+			[
+				"manif",
+				"manifest_template.json"
+			],
+			[
+				"inf",
+				"src/inject_frame.js"
+			],
+			[
+				"incon",
+				"src/inject_content.js"
+			],
+			[
+				"backg",
+				"src/background.js"
+			],
+			[
+				"opjs",
+				"src/options/options.js"
+			],
+			[
+				"opt",
+				"src/options/options.css"
+			],
+			[
+				"manife",
+				"manifest_template.json"
+			],
+			[
+				"in",
+				"src/inject_frame.js"
+			],
+			[
+				"options.html",
+				"src/options/options.html"
+			],
+			[
+				"popup",
+				"src/popup/popup.js"
+			],
+			[
+				"backgr",
+				"src/background.js"
+			],
+			[
+				"permiss",
+				"src/permission.js"
+			],
+			[
+				"prefmak",
+				"src/prefmaker.js"
+			],
+			[
+				"option",
+				"src/options/options.js"
+			],
+			[
+				"manifest",
+				"manifest_template.json"
+			],
+			[
+				"mani",
+				"manifest_template.json"
+			],
+			[
+				"infr",
+				"src/inject_frame.js"
+			],
+			[
+				"scrollable",
+				"src/ScrollableMap.js"
+			],
+			[
+				"grun",
+				"Gruntfile.js"
+			],
+			[
+				"gruntfil",
+				"Gruntfile.js"
+			],
+			[
+				"html",
+				"src/popup/popup.html"
+			],
+			[
+				"perm",
+				"src/permission.js"
+			],
+			[
+				"mapa",
 				"src/mapapi_inject.js"
 			],
 			[
 				"grunt",
 				"Gruntfile.js"
+			],
+			[
+				"scro",
+				"src/ScrollableMap.js"
+			],
+			[
+				"main",
+				"src/mapapi_inject.js"
 			],
 			[
 				"scroll",
@@ -821,20 +1363,8 @@
 				"gen/plugin-10000/mapapi_inject.min.js"
 			],
 			[
-				"grun",
-				"Gruntfile.js"
-			],
-			[
 				"scrollm",
 				"src/ScrollableMap.js"
-			],
-			[
-				"back",
-				"src/background.js"
-			],
-			[
-				"manifest",
-				"manifest_template.json"
 			],
 			[
 				"inject",
@@ -1069,10 +1599,6 @@
 				"parse/test/buildtags/buildtags_expected.go"
 			],
 			[
-				"main",
-				"main.go"
-			],
-			[
 				"parse",
 				"parse/parse.go"
 			],
@@ -1153,10 +1679,6 @@
 				"g.go"
 			],
 			[
-				"scrollmap",
-				"ScrollableMap.js"
-			],
-			[
 				"injec",
 				"src/inject_content.js"
 			],
@@ -1171,10 +1693,6 @@
 			[
 				"mapin",
 				"src/mapapi_inject.js"
-			],
-			[
-				"backgr",
-				"src/background.js"
 			],
 			[
 				"scin",
@@ -1193,10 +1711,6 @@
 				"src/inject_content.js"
 			],
 			[
-				"gruntfil",
-				"Gruntfile.js"
-			],
-			[
 				"maintest",
 				"main_test.go"
 			],
@@ -1209,112 +1723,12 @@
 				"src/options/options.css"
 			],
 			[
-				"ophtml",
-				"src/options/options.html"
-			],
-			[
 				"prefmake",
 				"src/prefmaker.js"
 			],
 			[
-				"option",
-				"src/options/options.js"
-			],
-			[
 				"pref",
 				"src/pref.js"
-			],
-			[
-				"options",
-				"src/options/options.html"
-			],
-			[
-				"option.html",
-				"options/options.html"
-			],
-			[
-				"npmrc",
-				".npmrc"
-			],
-			[
-				"pack",
-				"package.json"
-			],
-			[
-				"packa",
-				"package.json"
-			],
-			[
-				"package",
-				"package.json"
-			],
-			[
-				".py",
-				"generate_manifest.py"
-			],
-			[
-				"p",
-				"package.json"
-			],
-			[
-				"subj",
-				"subject.go"
-			],
-			[
-				"interfa",
-				"interface.go"
-			],
-			[
-				"string",
-				"string_test.go"
-			],
-			[
-				"confi",
-				"config.go"
-			],
-			[
-				"ass",
-				"assert.go"
-			],
-			[
-				"as",
-				"assert_test.go"
-			],
-			[
-				"asstet",
-				"assert_test.go"
-			],
-			[
-				"intetest",
-				"interface_test.go"
-			],
-			[
-				"",
-				"interface.go"
-			],
-			[
-				"field",
-				"field_tag.go"
-			],
-			[
-				"co",
-				"cobragen.go"
-			],
-			[
-				"usage",
-				"usage_test.go"
-			],
-			[
-				"pre",
-				"ex3/predict.m"
-			],
-			[
-				"nn",
-				"ex3/ex3_nn.m"
-			],
-			[
-				"cost",
-				"ex3/lrCostFunction.m"
 			]
 		],
 		"width": 0.0

--- a/src/ScrollableMap.js
+++ b/src/ScrollableMap.js
@@ -259,8 +259,8 @@ var ScrollableMap = function (div, type, id) {
         }
 
         var target = e.target || e.srcElement;
-        var isAccelerating = (!pref('isolateZoomScroll') ||
-            accelero.isAccelerating(e.wheelDeltaX, e.wheelDeltaY, e.timeStamp));
+        var isAccelerating =
+            accelero.isAccelerating(e.wheelDeltaX, e.wheelDeltaY, e.timeStamp);
 
         if (Scrollability.hasScrollableParent(target, div)) {
             // something is scrollable, let's allow it to scroll

--- a/src/ScrollableMap.js
+++ b/src/ScrollableMap.js
@@ -4,6 +4,8 @@ const DEBUG = false;
 
 var ScrollableMap = function (div, type, id) {
 
+    chrome.runtime.sendMessage({'action': 'mapLoaded'});
+
     function _findAncestorScrollMap(node) {
         if (!(node instanceof Element)) {
             return null;
@@ -43,6 +45,8 @@ var ScrollableMap = function (div, type, id) {
 
     var mapClicked; // whether the map has ever been clicked (to activate the map)
     var bodyScrolls = false;
+
+    div.setAttribute('data-scrollmaps', id);
 
     var style = document.createElement('style');
     style.innerHTML =   '.gmnoprint, .gm-style .place-card, .gm-style .login-control { -webkit-transition: opacity 0.3s !important; }' +

--- a/src/background.js
+++ b/src/background.js
@@ -21,7 +21,9 @@ function injectScript(tabId, frameId) {
         let errorMessage = lastError ? lastError.message : undefined;
         if (DEBUG) {
             console.log(tabId, errorMessage);
-        } else if (errorMessage && errorMessage.indexOf('Cannot access') === -1) {
+        } else if (errorMessage
+            && errorMessage.indexOf('Cannot access') === -1
+            && errorMessage.indexOf('The extensions gallery cannot be scripted') === -1) {
             console.warn(tabId, errorMessage);
         }
     });
@@ -140,12 +142,6 @@ chrome.browserAction.setBadgeBackgroundColor({'color': '#4caf50'});
 
 chrome.runtime.onMessage.addListener(
     (request, sender, sendResponse) => {
-        if (request.action === 'optionsPageLoaded') {
-            // Workaround for https://bugs.chromium.org/p/chromium/issues/detail?id=30756 where
-            // content scripts defined in the manifest doesn't work for pages hosted by the
-            // extension itself.
-            injectScript(sender.tab.id, undefined);
-        }
         if (request.action === 'mapLoaded') {
             if (DEBUG) {
                 console.log('mapLoaded', sender.tab);

--- a/src/background.js
+++ b/src/background.js
@@ -50,6 +50,14 @@ chrome.webRequest.onBeforeRequest.addListener(
 chrome.browserAction.onClicked.addListener((tab) => {
     injectScript(tab.id, 'all');
     setBrowserActionBadge(tab.id, BADGE_LOADING);
+    setTimeout(() => {
+        // Remove the loading badge if no maps responded in 10s
+        chrome.browserAction.getBadgeText({'tabId': tab.id}, (text) => {
+            if (text === BADGE_LOADING) {
+                setBrowserActionBadge(tab.id, '');
+            }
+        });
+    }, 10000);
 });
 
 function refreshBrowserAction(tab) {

--- a/src/background.js
+++ b/src/background.js
@@ -30,3 +30,16 @@ chrome.webRequest.onBeforeRequest.addListener(
         return {};
     },
     {urls: ["*://maps.googleapis.com/*"]});
+
+chrome.browserAction.onClicked.addListener((tab) => {
+    chrome.tabs.executeScript(tab.id, {
+        'file': 'mapapi_inject.min.js',
+        'runAt': 'document_start',
+        'allFrames': true
+    });
+    chrome.tabs.executeScript(tab.id, {
+        'file': 'scrollability_inject.min.js',
+        'runAt': 'document_idle',
+        'allFrames': true
+    });
+});

--- a/src/background.js
+++ b/src/background.js
@@ -32,13 +32,13 @@ chrome.webRequest.onBeforeRequest.addListener(
     {urls: ["*://maps.googleapis.com/*"]});
 
 async function initializeTab(tab) {
-    if (tab.url.indexOf('chrome://') === 0) {
+    if (tab.url.indexOf('chrome://') === 0 || tab.url.indexOf('chrome-extension://') === 0) {
         // This extension can't inject into chrome:// pages. Just show the popup
         // directly
         updateBrowserAction(tab, {active: false})
         return;
     }
-    if (Permission.isMapsSite(tab.url)) {
+    if (Permission.isMapsSite(tab.url) || Permission.isRequiredPermission(tab.url)) {
         updateBrowserAction(tab);
         return;
     }

--- a/src/background.js
+++ b/src/background.js
@@ -2,6 +2,23 @@
 
 const DEBUG = false;
 
+const BADGE_ACTIVE = '\u2713';
+const BADGE_LOADING = '\u21bb';
+
+function injectScript(tabId, frameId) {
+    chrome.tabs.executeScript(tabId, {
+        'file': 'mapapi_inject.min.js',
+        'runAt': 'document_start',
+        'frameId': frameId === 'all' ? null : frameId,
+        'allFrames': frameId === 'all'
+    });
+    chrome.tabs.executeScript(tabId, {
+        'file': 'scrollability_inject.min.js',
+        'runAt': 'document_idle',
+        'allFrames': true
+    });
+}
+
 chrome.webRequest.onBeforeRequest.addListener(
     function(details) {
         if (details.type === 'script') {
@@ -12,16 +29,7 @@ chrome.webRequest.onBeforeRequest.addListener(
                 console.warn('Tab ID is less than 0', details);
                 return {};
             }
-            chrome.tabs.executeScript(details.tabId, {
-                'file': 'mapapi_inject.min.js',
-                'runAt': 'document_start',
-                'frameId': details.frameId
-            });
-            chrome.tabs.executeScript(details.tabId, {
-                'file': 'scrollability_inject.min.js',
-                'runAt': 'document_idle',
-                'allFrames': true
-            });
+            injectScript(details.tabId, details.frameId);
         } else {
             if (DEBUG) {
                 console.log('Non matching request', details);
@@ -31,29 +39,58 @@ chrome.webRequest.onBeforeRequest.addListener(
     },
     {urls: ["*://maps.googleapis.com/*"]});
 
-async function initializeTab(tab) {
-    if (tab.url.indexOf('chrome://') === 0 || tab.url.indexOf('chrome-extension://') === 0) {
+chrome.browserAction.onClicked.addListener((tab) => {
+    injectScript(tab.id, 'all');
+    setBrowserActionBadge(tab.id, BADGE_LOADING);
+});
+
+function refreshBrowserAction(tab) {
+    if (DEBUG) {
+        console.log('initialize tab', tab);
+    }
+    if (tab.url.indexOf('chrome://') === 0
+        || tab.url.indexOf('chrome-extension://') === 0) {
         // This extension can't inject into chrome:// pages. Just show the popup
         // directly
-        updateBrowserAction(tab, {active: false})
+        setBrowserActionBadge(tab.id, undefined)
         return;
     }
-    if (Permission.isMapsSite(tab.url) || Permission.isRequiredPermission(tab.url)) {
-        updateBrowserAction(tab);
+    if (Permission.isRequiredPermission(tab.url)) {
+        // If the permission is required (e.g. if it is on the domain
+        // google.com), we cannot allow users to toggle the permission.
+        setBrowserActionBadge(tab.id, undefined)
         return;
     }
-    let siteStatus = await Permission.loadSiteStatus(tab.url);
-    if (siteStatus.isSiteGranted || siteStatus.isAllGranted) {
-        updateBrowserAction(tab);
-        return;
-    }
-    updateBrowserAction(tab, {active: false, popup: false});
+}
+
+function refreshScrollMapsStatus(tabId, tab) {
+    // Check if the map already has a scrollmaps injected (e.g. after extension reloading)
+    chrome.tabs.executeScript(tabId, {
+        'code': '!!document.querySelector("[data-scrollmaps]")',
+        'runAt': 'document_start'
+    }, (response) => {
+        if (DEBUG) {
+            console.log('response', tab, response);
+        }
+        if (response && response[0]) {
+            setBrowserActionBadge(tabId, BADGE_ACTIVE);
+        }
+        // Ignore the error
+        let lastError = chrome.runtime.lastError;
+        let errorMessage = lastError ? lastError.message : undefined;
+        if (DEBUG) {
+            console.log(tabId, errorMessage);
+        } else if (errorMessage && errorMessage.indexOf('Cannot access') === -1) {
+            console.warn(tabId, errorMessage);
+        }
+    });
 }
 
 function updateAllTabs() {
     chrome.tabs.query({}, (tabs) => {
         for (let tab of tabs) {
-            initializeTab(tab);
+            refreshBrowserAction(tab);
+            refreshScrollMapsStatus(tab.id, tab);
         }
     });
 }
@@ -61,35 +98,40 @@ function updateAllTabs() {
 updateAllTabs();
 
 chrome.tabs.onUpdated.addListener(
-    (tabId, changeInfo, tab) => initializeTab(tab));
-
-function updateBrowserAction(tab, {active = true, popup = true} = {}) {
-    chrome.browserAction.setBadgeText({
-        'text': active ? '\u2713' : '',
-        'tabId': tab.id
+    (tabId, changeInfo, tab) => {
+        if (changeInfo.status === 'complete') {
+            refreshBrowserAction(tab);
+        }
     });
+
+function setBrowserActionBadge(
+        tabId,
+        badge,
+        {popup = true} = {}) {
+    if (badge !== undefined) {
+        chrome.browserAction.setBadgeText({
+            'text': badge,
+            'tabId': tabId
+        });
+    }
     chrome.browserAction.setPopup({
-        'tabId': tab.id,
+        'tabId': tabId,
         'popup': popup ? chrome.runtime.getURL('src/popup/popup.html') : '',
     });
 }
 
 chrome.browserAction.setBadgeBackgroundColor({'color': '#4caf50'});
 
-chrome.browserAction.onClicked.addListener((tab) => {
-    chrome.tabs.executeScript(tab.id, {
-        'file': 'mapapi_inject.min.js',
-        'runAt': 'document_start',
-        'allFrames': true
+chrome.runtime.onMessage.addListener(
+    (request, sender, sendResponse) => {
+        if (request.action === 'mapLoaded') {
+            if (DEBUG) {
+                console.log('mapLoaded', sender.tab);
+            }
+            if (sender.tab) {
+                setBrowserActionBadge(sender.tab.id, BADGE_ACTIVE);
+            } else {
+                console.warn('mapLoaded sent without tab', sender);
+            }
+        }
     });
-    chrome.tabs.executeScript(tab.id, {
-        'file': 'scrollability_inject.min.js',
-        'runAt': 'document_idle',
-        'allFrames': true
-    });
-
-    updateBrowserAction(tab);
-});
-
-chrome.permissions.onAdded.addListener((permissions) => updateAllTabs());
-chrome.permissions.onRemoved.addListener((permissions) => updateAllTabs());

--- a/src/background.js
+++ b/src/background.js
@@ -88,3 +88,5 @@ chrome.browserAction.onClicked.addListener((tab) => {
 
     updateBrowserAction(tab);
 });
+
+// TODO: Fix cross site active badge

--- a/src/background.js
+++ b/src/background.js
@@ -140,6 +140,12 @@ chrome.browserAction.setBadgeBackgroundColor({'color': '#4caf50'});
 
 chrome.runtime.onMessage.addListener(
     (request, sender, sendResponse) => {
+        if (request.action === 'optionsPageLoaded') {
+            // Workaround for https://bugs.chromium.org/p/chromium/issues/detail?id=30756 where
+            // content scripts defined in the manifest doesn't work for pages hosted by the
+            // extension itself.
+            injectScript(sender.tab.id, undefined);
+        }
         if (request.action === 'mapLoaded') {
             if (DEBUG) {
                 console.log('mapLoaded', sender.tab);

--- a/src/background.js
+++ b/src/background.js
@@ -31,6 +31,8 @@ chrome.webRequest.onBeforeRequest.addListener(
     },
     {urls: ["*://maps.googleapis.com/*"]});
 
+// TODO: Indicator of whether the extension is active
+
 chrome.browserAction.onClicked.addListener((tab) => {
     chrome.tabs.executeScript(tab.id, {
         'file': 'mapapi_inject.min.js',
@@ -41,5 +43,10 @@ chrome.browserAction.onClicked.addListener((tab) => {
         'file': 'scrollability_inject.min.js',
         'runAt': 'document_idle',
         'allFrames': true
+    });
+
+    chrome.browserAction.setPopup({
+        'tabId': tab.id,
+        'popup': chrome.runtime.getURL('src/popup/popup.html'),
     });
 });

--- a/src/background.js
+++ b/src/background.js
@@ -16,6 +16,14 @@ function injectScript(tabId, frameId) {
         'file': 'scrollability_inject.min.js',
         'runAt': 'document_idle',
         'allFrames': true
+    }, (result) => {
+        let lastError = chrome.runtime.lastError;
+        let errorMessage = lastError ? lastError.message : undefined;
+        if (DEBUG) {
+            console.log(tabId, errorMessage);
+        } else if (errorMessage && errorMessage.indexOf('Cannot access') === -1) {
+            console.warn(tabId, errorMessage);
+        }
     });
 }
 
@@ -27,7 +35,7 @@ chrome.webRequest.onBeforeRequest.addListener(
             }
             if (details.tabId < 0) {
                 console.warn('Tab ID is less than 0', details);
-                return {};
+                return;
             }
             injectScript(details.tabId, details.frameId);
         } else {
@@ -35,7 +43,7 @@ chrome.webRequest.onBeforeRequest.addListener(
                 console.log('Non matching request', details);
             }
         }
-        return {};
+        return;
     },
     {urls: ["*://maps.googleapis.com/*"]});
 

--- a/src/inject_content.js
+++ b/src/inject_content.js
@@ -1,10 +1,10 @@
 (function () {
 
-    var TYPE_WEB = 0;
-    var TYPE_IFRAME = 1;
-    var TYPE_API = 2;
-    var TYPE_NEWWEB = 3;
-    var TYPE_STREETVIEW_API = 4;
+    const TYPE_WEB = 0;
+    const TYPE_IFRAME = 1;
+    const TYPE_API = 2;
+    const TYPE_NEWWEB = 3;
+    const TYPE_STREETVIEW_API = 4;
 
     function init() {
         function newMapNotifier (parent, propname, Map) {

--- a/src/inject_content.js
+++ b/src/inject_content.js
@@ -27,7 +27,6 @@
                     }
                 }
                 var uid = Math.floor(Math.random() * 100000);
-                container.setAttribute('data-scrollmaps', uid);
                 dispatchEventWhenAttached(container, 'mapsFound', {'id': uid, 'type': TYPE_API});
                 Map.call(this, container, opts);
 
@@ -60,7 +59,6 @@
                 var uid = Math.floor(Math.random() * 100000);
                 dispatchEventWhenAttached(container, 'mapsFound',
                     {'id': uid, 'type': TYPE_STREETVIEW_API});
-                container.setAttribute('data-scrollmaps', uid);
                 StreetView.call(this, container, opts);
 
                 return this;

--- a/src/inject_frame.js
+++ b/src/inject_frame.js
@@ -17,12 +17,7 @@ function injectMaps() {
 }
 
 function injectFrame() {
-    // Don't activate this thing at all if the frame has no map
-    if (SM.inframe) {
-        console.log('ignoring frame');
-        return;
-    }
-    var elem = document.getElementById('map');
+    let elem = document.getElementById('map');
     elem = elem || document.getElementById('mapDiv');
     if (elem) {
         new ScrollableMap(

--- a/src/inject_frame.js
+++ b/src/inject_frame.js
@@ -25,7 +25,10 @@ function injectFrame() {
     var elem = document.getElementById('map');
     elem = elem || document.getElementById('mapDiv');
     if (elem) {
-        new ScrollableMap(elem, (SM.inframe) ? ScrollableMap.TYPE_IFRAME : ScrollableMap.TYPE_WEB, SM.count++);
+        new ScrollableMap(
+            elem,
+            (SM.inframe) ? ScrollableMap.TYPE_IFRAME : ScrollableMap.TYPE_WEB,
+            SM.count++);
     } else if (!SM.inframe) {
         injectMaps();
     }

--- a/src/mapapi_inject.js
+++ b/src/mapapi_inject.js
@@ -40,16 +40,22 @@ let GoogleMapFinder = {};
 GoogleMapFinder._findGmStyleMap = function() {
     return Array.from(document.querySelectorAll('.gm-style'))
         .filter(container =>
-            _querySrc(container, 'img', '//maps.googleapis.com/maps/')
-                || _querySrc(container, 'img', '//www.google.com/maps/')
+            _querySrc(container, 'img',
+                [
+                    '//maps.googleapis.com/maps/',
+                    '//www.google.com/maps/',
+                    '//maps.google.com/maps/'
+                ])
                 || container.querySelector('canvas'))
         .map(container => container.parentNode);
 };
 
-function _querySrc(container, tag, substring) {
+function _querySrc(container, tag, possible_substrings) {
     for (let elem of container.querySelectorAll(tag)) {
-        if (elem.src.indexOf(substring) !== -1) {
-            return true;
+        for (let substring of possible_substrings) {
+            if (elem.src.indexOf(substring) !== -1) {
+                return true;
+            }
         }
     }
     return false;

--- a/src/mapapi_inject.js
+++ b/src/mapapi_inject.js
@@ -79,6 +79,9 @@ GoogleMapFinder.findMaps = function() {
 
 function scrollifyExistingMaps() {
     maps = GoogleMapFinder.findMaps();
+    if (DEBUG) {
+        console.log('existing maps', maps);
+    }
     if (maps.length <= 0) {
         return false;
     }

--- a/src/mapapi_inject.js
+++ b/src/mapapi_inject.js
@@ -40,10 +40,20 @@ let GoogleMapFinder = {};
 GoogleMapFinder._findGmStyleMap = function() {
     return Array.from(document.querySelectorAll('.gm-style'))
         .filter(container =>
-            container.querySelector('img[src*="//maps.googleapis.com/maps/"]')
+            _querySrc(container, 'img', '//maps.googleapis.com/maps/')
+                || _querySrc(container, 'img', '//www.google.com/maps/')
                 || container.querySelector('canvas'))
         .map(container => container.parentNode);
 };
+
+function _querySrc(container, tag, substring) {
+    for (let elem of container.querySelectorAll(tag)) {
+        if (elem.src.indexOf(substring) !== -1) {
+            return true;
+        }
+    }
+    return false;
+}
 
 GoogleMapFinder._findFallbackMap = function() {
     let foundImages = Array.from(

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -14,15 +14,13 @@ body { background-color: whiteSmoke; font-family: Helvetica, Trebuchet MS, Arial
 #box-content { padding: 15px; }
 #header {   font-family: Century Gothic, Arial, sans-serif; -webkit-user-select: none; cursor: default;
             font-size: 30px; margin: auto; color: #333; text-shadow: 0 1px 1px white; 
-            /*background: -webkit-linear-gradient(top, white 0%, #EEE 60%, #F5F5F5 90%); border: 1px solid #BBB;
-            -webkit-border-radius: 5px; padding: 2px 5px; -webkit-box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.50); */
         }
 
 .horizontalLine { border-top: 1px solid #CCC; border-bottom: 1px solid #FFF; margin: 5px 0px; }
 .clear { clear: both; }
 
 #checkboxes { display: inline-block; width: 350px; height: 480px; float: left; position: relative; }
-#mapsdemo { border: 1px solid #BBB; float: right; }
+#mapsdemo { width: 300px; height: 470px; border: 1px solid #BBB; float: right; }
 
 #zoomhint { position: absolute; bottom: 3px; right: 5px; font-size: 12px; text-shadow: 0 1px 1px white; color: #888; -webkit-user-select: none; cursor: default; }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -11,7 +11,7 @@
                     <div id="headerwrap"><div id="header">ScrollMaps Options</div></div>
                     <div class="horizontalLine"></div>
                 </div>
-                <iframe id="mapsdemo" width="300" height="470" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="http://maps.google.com/?ie=UTF8&amp;hq=&amp;t=m&amp;vpsrc=6&amp;ll=39.571822,-91.318359&amp;spn=11.849194,13.183594&amp;z=5&amp;output=embed"></iframe>
+                <iframe id="mapsdemo" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://www.google.com/maps/embed/v1/view?key=AIzaSyCs4QGENEbwHZlRhMfpu4Xq2pTlwaQvb9w&zoom=12&center=37.3861%2C-122.0839"></iframe>
                 <div class="clear"></div>
             </div>
         </div>
@@ -21,5 +21,6 @@
     <script src="../pref.js" type="text/javascript"></script>
     <script src="../prefmaker.js" type="text/javascript"></script>
     <script src="options.js" type="text/javascript"></script>
+    <script src="../permission.js" type="text/javascript"></script>
     <script src="../Scrollability.js" type="text/javascript"></script>
 </html>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,7 +1,5 @@
 var Options = {};
 
-chrome.runtime.sendMessage({'action': 'optionsPageLoaded'});
-
 (function(){
 
     Options.createOptions = function(){

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,5 +1,7 @@
 var Options = {};
 
+chrome.runtime.sendMessage({'action': 'optionsPageLoaded'});
+
 (function(){
 
     Options.createOptions = function(){
@@ -47,12 +49,13 @@ var Options = {};
         );
         box.append(frameRequireFocusCheckbox);
 
-        var isolateZoomScrollCheckbox = PrefMaker.makeBooleanCheckbox(
-            'isolateZoomScroll',
-            'Detect Finger Lift',
-            'To isolate scrolling gestures from zooming'
+        var allowAccessToAllSites = PrefMaker.makePermissionCheckbox(
+            'allowAccessToAllSites',
+            '<all_urls>',
+            'Allow ScrollMaps on all sites',
+            'Any sites that embed Google Maps will enable scrolling automatically'
         );
-        box.append(isolateZoomScrollCheckbox);
+        box.append(allowAccessToAllSites);
 
         box.append('<div id="zoomhint">Pinch to zoom in or out</div>');
     };

--- a/src/permission.js
+++ b/src/permission.js
@@ -28,3 +28,48 @@ Permission.isMapsSite = function (urlString) {
     }
     return false;
 }
+
+const MATCH_PATTERN = /^(\*|http|https|file|ftp):\/\/(\*|(?:\*\.)?[^*/]*)(?:\/(.*))?$/;
+
+Permission.isRequiredPermission = function (url) {
+    for (let domain of SCROLLMAPS_DOMAINS) {
+        if (_matchDomainPattern(domain, url)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function _matchDomainPattern(pattern, url) {
+    let regex = pattern.replace(MATCH_PATTERN, (match, scheme, host, path, offset, string) => {
+        let result = '';
+        if (scheme === '*') {
+            result += '(http|https)';
+        } else {
+            result += scheme;
+        }
+        result += '://';
+        result += host.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&').replace('\\*', '[^\./]*');
+        result += '.*';
+        return result;
+    });
+    return !!url.match(regex);
+}
+
+function _matchPattern(pattern, url) {
+    let regex = pattern.replace(MATCH_PATTERN, (match, scheme, host, path, offset, string) => {
+        let result = '';
+        if (scheme === '*') {
+            result += '(http|https)';
+        } else {
+            result += scheme;
+        }
+        result += '://';
+        result += host.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&').replace('\\*', '[^\./]*');
+        result += '(/';
+        result += path.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&').replace('\\*', '.*');
+        result += ')?';
+        return result;
+    });
+    return !!url.match(regex);
+}

--- a/src/permission.js
+++ b/src/permission.js
@@ -18,13 +18,11 @@ Permission.loadSiteStatus = async function (url) {
     };
 }
 
-Permission.isMapsSite = function (urlString) {
-    let url = new URL(urlString);
-    if (url.host === 'maps.google.com') {
-        return true;
-    }
-    if (url.host === 'google.com' || url.host === 'www.google.com') {
-        return url.pathname.indexOf('/maps/') === 0;
+Permission.isMapsSite = function (url) {
+    for (let domain of SCROLLMAPS_DOMAINS) {
+        if (_matchPattern(domain, url)) {
+            return true;
+        }
     }
     return false;
 }

--- a/src/permission.js
+++ b/src/permission.js
@@ -1,0 +1,30 @@
+let Permission = {};
+
+Permission.getPermissions = function (urls) {
+    return new Promise((resolve, reject) => {
+        chrome.permissions.contains({'origins': urls}, resolve);
+    });
+}
+
+Permission.loadSiteStatus = async function (url) {
+    let [isSiteGranted, isAllGranted] = await Promise.all([
+        Permission.getPermissions([url]),
+        Permission.getPermissions(['<all_urls>'])
+    ]);
+    return {
+        'tabUrl': url,
+        'isSiteGranted': isSiteGranted || Permission.isMapsSite(url),
+        'isAllGranted': isAllGranted
+    };
+}
+
+Permission.isMapsSite = function (urlString) {
+    let url = new URL(urlString);
+    if (url.host === 'maps.google.com') {
+        return true;
+    }
+    if (url.host === 'google.com' || url.host === 'www.google.com') {
+        return url.pathname.indexOf('/maps/') === 0;
+    }
+    return false;
+}

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -9,22 +9,14 @@ body { background-color: whiteSmoke; font-family: Helvetica, Trebuchet MS, Arial
     border-radius: 5px;
     box-sizing: border-box;
 }
-#box-content { padding: 15px; }
-#header {   font-family: Century Gothic, Arial, sans-serif; -webkit-user-select: none; cursor: default;
-            font-size: 30px; margin: auto; color: #333; text-shadow: 0 1px 1px white; 
-            /*background: -webkit-linear-gradient(top, white 0%, #EEE 60%, #F5F5F5 90%); border: 1px solid #BBB;
-            -webkit-border-radius: 5px; padding: 2px 5px; -webkit-box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.50); */
-        }
+.box-content { padding: 15px; }
 
-.horizontalLine { border-top: 1px solid #CCC; border-bottom: 1px solid #FFF; margin: 5px 0px; }
-.clear { clear: both; }
+.disable-options .PMcheckbox { display: none; }
 
-#checkboxes { display: inline-block; width: 350px; height: 480px; float: left; position: relative; }
+.PMcheckbox { margin: 7px 0px; display: flex; vertical-align: middle; }
+.PMcheckbox input { margin-right: 10px; }
+.PMcheckbox label { vertical-align: middle; display: inline-block; }
 
-.PMradio { margin: 7px 0px; display: flex; vertical-align: middle; }
-.PMradio input { margin-right: 10px; }
-.PMradio label { vertical-align: middle; display: inline-block; }
-
-.PMradio_labelwrap { display: inline-block; -webkit-user-select: none; margin: 5px 0px; }
-.PMradio_labeltext { margin: 2px 0px; }
-.PMradio_smalltext { color: #666; font-size: 12px; }
+label.disabled { opacity: 0.3; }
+.PMcheckbox_labeltext { margin: 2px 0px; }
+.PMcheckbox_smalltext { color: #666; font-size: 12px; }

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1,0 +1,30 @@
+body { background-color: whiteSmoke; font-family: Helvetica, Trebuchet MS, Arial, sans-serif; font-size: 14px; }
+
+#box {
+    background: -webkit-linear-gradient(top, #DDD 0%, #EAEAEA 1% );
+    border: 1px solid #BBB;
+    margin: auto;
+    position: relative;
+    width: 300px;
+    border-radius: 5px;
+    box-sizing: border-box;
+}
+#box-content { padding: 15px; }
+#header {   font-family: Century Gothic, Arial, sans-serif; -webkit-user-select: none; cursor: default;
+            font-size: 30px; margin: auto; color: #333; text-shadow: 0 1px 1px white; 
+            /*background: -webkit-linear-gradient(top, white 0%, #EEE 60%, #F5F5F5 90%); border: 1px solid #BBB;
+            -webkit-border-radius: 5px; padding: 2px 5px; -webkit-box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.50); */
+        }
+
+.horizontalLine { border-top: 1px solid #CCC; border-bottom: 1px solid #FFF; margin: 5px 0px; }
+.clear { clear: both; }
+
+#checkboxes { display: inline-block; width: 350px; height: 480px; float: left; position: relative; }
+
+.PMradio { margin: 7px 0px; display: flex; vertical-align: middle; }
+.PMradio input { margin-right: 10px; }
+.PMradio label { vertical-align: middle; display: inline-block; }
+
+.PMradio_labelwrap { display: inline-block; -webkit-user-select: none; margin: 5px 0px; }
+.PMradio_labeltext { margin: 2px 0px; }
+.PMradio_smalltext { color: #666; font-size: 12px; }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -26,6 +26,7 @@
         </div>
     </body>
     <script src="../jquery.js" type="text/javascript"></script>
+    <script src="../domains.js" type="text/javascript"></script>
     <script src="../permission.js" type="text/javascript"></script>
     <script src="popup.js" type="text/javascript"></script>
 </html>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -6,31 +6,26 @@
     </head>
     <body>
         <div id="box">
-            <div id="box-content">
-                <div class="PMradio">
-                    <input type="radio" id="not_granted" name="permission" value="not_granted" checked />
-                    <label for="not_granted">
-                        <div class="PMradio_labeltext">Activate ScrollMaps on click</div>
-                        <div class="PMradio_smalltext">Click on the extension icon each time</div>
-                    </label>
-                </div>
-                <div class="PMradio">
-                    <input type="radio" id="site_granted" name="permission" value="site_granted" />
+            <div id="permissionOptions" class="box-content">
+                <div id="permissionExplanation">Activate ScrollMaps by clicking the extension icon</div>
+                <div class="PMcheckbox">
+                    <input type="checkbox" id="site_granted" name="permission" />
                     <label for="site_granted">
-                        <div class="PMradio_labeltext">Auto-activate on this site</div>
-                        <div class="PMradio_smalltext">Allow ScrollMaps to access this domain</div>
+                        <div class="PMcheckbox_labeltext">Auto-activate on this site</div>
+                        <div class="PMcheckbox_smalltext">Enable ScrollMaps on this site without having to click on the extension icon</div>
                     </label>
                 </div>
-                <div class="PMradio">
-                    <input type="radio" id="all_granted" name="permission" value="all_granted" />
+                <div class="PMcheckbox">
+                    <input type="checkbox" id="all_granted" name="permission" />
                     <label for="all_granted">
-                        <div class="PMradio_labeltext">Auto-activate on all sites</div>
-                        <div class="PMradio_smalltext">Allow ScrollMaps to access all URLs</div>
+                        <div class="PMcheckbox_labeltext">Auto-activate on all sites</div>
+                        <div class="PMcheckbox_smalltext">Enable ScrollMaps on all sites without having to click on the extension icon</div>
                     </label>
                 </div>
             </div>
         </div>
     </body>
     <script src="../jquery.js" type="text/javascript"></script>
+    <script src="../permission.js" type="text/javascript"></script>
     <script src="popup.js" type="text/javascript"></script>
 </html>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -1,0 +1,36 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <title>ScrollMaps options</title>
+        <link rel="stylesheet" href="popup.css" type="text/css" />
+    </head>
+    <body>
+        <div id="box">
+            <div id="box-content">
+                <div class="PMradio">
+                    <input type="radio" id="not_granted" name="permission" value="not_granted" checked />
+                    <label for="not_granted">
+                        <div class="PMradio_labeltext">Activate ScrollMaps on click</div>
+                        <div class="PMradio_smalltext">Click on the extension icon each time</div>
+                    </label>
+                </div>
+                <div class="PMradio">
+                    <input type="radio" id="site_granted" name="permission" value="site_granted" />
+                    <label for="site_granted">
+                        <div class="PMradio_labeltext">Auto-activate on this site</div>
+                        <div class="PMradio_smalltext">Allow ScrollMaps to access this domain</div>
+                    </label>
+                </div>
+                <div class="PMradio">
+                    <input type="radio" id="all_granted" name="permission" value="all_granted" />
+                    <label for="all_granted">
+                        <div class="PMradio_labeltext">Auto-activate on all sites</div>
+                        <div class="PMradio_smalltext">Allow ScrollMaps to access all URLs</div>
+                    </label>
+                </div>
+            </div>
+        </div>
+    </body>
+    <script src="../jquery.js" type="text/javascript"></script>
+    <script src="popup.js" type="text/javascript"></script>
+</html>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,10 +1,6 @@
 (function(){
 
     let siteStatus = loadSiteStatus();
-    const REQUIRED_PERMISSION_ORIGINS = [
-        'www.google.com',
-        'maps.google.com'
-    ];
 
     function getTabUrl() {
         return new Promise((resolve, reject) => {
@@ -25,8 +21,7 @@
 
     $('#site_granted').change(function() {
         siteStatus.then((status) => {
-            if (REQUIRED_PERMISSION_ORIGINS.includes(
-                    new URL(status.tabUrl).host)) {
+            if (Permission.isRequiredPermission(status.tabUrl)) {
                 return;
             }
             if ($(this).prop('checked')) {
@@ -38,6 +33,7 @@
     });
     $('#all_granted').change(function() {
         let allGranted = $(this).prop('checked');
+        $('#site_granted').prop('checked', allGranted);
         if (allGranted) {
             chrome.permissions.request({origins: ['<all_urls>']});
         } else {
@@ -66,7 +62,7 @@
                 return;
             }
             let host = new URL(status.tabUrl).host;
-            if (REQUIRED_PERMISSION_ORIGINS.includes(host)) {
+            if (Permission.isRequiredPermission(status.tabUrl)) {
                 $(document.body).addClass('disable-options');
                 $('#permissionExplanation').text(
                     `ScrollMaps is enabled on ${host}`);

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -70,7 +70,7 @@
                 return;
             }
 
-            $('label[for=site_granted] .PMradio_smalltext')
+            $('label[for=site_granted] .PMcheckbox_smalltext')
                 .text(`Enable ScrollMaps on ${host} without having to click on the extension icon`);
 
             $('#all_granted').prop('checked', status.isAllGranted);

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,0 +1,68 @@
+(function(){
+
+    let siteStatus = loadSiteStatus();
+
+    function getTabUrl() {
+        return new Promise((resolve, reject) => {
+            chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
+                if (tabs) {
+                    resolve(tabs[0].url);
+                } else {
+                    reject('No active tab but browser action received');
+                }
+            });
+        });
+    }
+
+    function loadSiteStatus() {
+        return getTabUrl().then(url => 
+            new Promise((resolve, reject) => {
+                chrome.permissions.contains({'origins': [url]},
+                    (isSiteGranted) => {
+                        chrome.permissions.contains({'origins': ['<all_urls>']},
+                            (isAllGranted) => {
+                                resolve({
+                                    'tabUrl': url,
+                                    'isSiteGranted': isSiteGranted,
+                                    'isAllGranted': isAllGranted
+                                })
+                            });
+                    });
+            }));
+    }
+
+    $('input[type=radio][name=permission]').change(function() {
+        if (this.value === 'site_granted') {
+            siteStatus.then((status) =>
+                chrome.permissions.request(
+                    {origins: [status.tabUrl]},
+                    () => {
+                        // Remove only after we have granted the current site
+                        chrome.permissions.remove({origins: ['<all_urls>']});
+                    }));
+        } else if (this.value === 'all_granted') {
+            chrome.permissions.request({origins: ['<all_urls>']});
+        } else if (this.value === 'not_granted') {
+            siteStatus.then((status) =>
+                chrome.permissions.remove({
+                    origins: [status.tabUrl, '<all_urls>']
+                }));
+        }
+    });
+
+    $(function(){
+        siteStatus.then(status => {
+            if (status.isAllGranted) {
+                $('#all_granted').prop('checked', true);
+            } else if (status.isSiteGranted) {
+                $('#site_granted').prop('checked', true);
+            } else {
+                $('#not_granted').prop('checked', true);
+            }
+
+            let host = new URL(status.tabUrl).host;
+            $('label[for=site_granted] .PMradio_smalltext')
+                .text(`Allow ScrollMaps to access ${host}`);
+        });
+    });
+})();

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,6 +1,10 @@
 (function(){
 
     let siteStatus = loadSiteStatus();
+    const REQUIRED_PERMISSION_ORIGINS = [
+        'www.google.com',
+        'maps.google.com'
+    ];
 
     function getTabUrl() {
         return new Promise((resolve, reject) => {
@@ -14,55 +18,67 @@
         });
     }
 
-    function loadSiteStatus() {
-        return getTabUrl().then(url => 
-            new Promise((resolve, reject) => {
-                chrome.permissions.contains({'origins': [url]},
-                    (isSiteGranted) => {
-                        chrome.permissions.contains({'origins': ['<all_urls>']},
-                            (isAllGranted) => {
-                                resolve({
-                                    'tabUrl': url,
-                                    'isSiteGranted': isSiteGranted,
-                                    'isAllGranted': isAllGranted
-                                })
-                            });
-                    });
-            }));
+    async function loadSiteStatus() {
+        let url = await getTabUrl();
+        return await Permission.loadSiteStatus(url);
     }
 
-    $('input[type=radio][name=permission]').change(function() {
-        if (this.value === 'site_granted') {
-            siteStatus.then((status) =>
-                chrome.permissions.request(
-                    {origins: [status.tabUrl]},
-                    () => {
-                        // Remove only after we have granted the current site
-                        chrome.permissions.remove({origins: ['<all_urls>']});
-                    }));
-        } else if (this.value === 'all_granted') {
-            chrome.permissions.request({origins: ['<all_urls>']});
-        } else if (this.value === 'not_granted') {
-            siteStatus.then((status) =>
-                chrome.permissions.remove({
-                    origins: [status.tabUrl, '<all_urls>']
-                }));
-        }
+    $('#site_granted').change(function() {
+        siteStatus.then((status) => {
+            if (REQUIRED_PERMISSION_ORIGINS.includes(
+                    new URL(status.tabUrl).host)) {
+                return;
+            }
+            if ($(this).prop('checked')) {
+                chrome.permissions.request({origins: [status.tabUrl]});
+            } else {
+                chrome.permissions.remove({origins: [status.tabUrl]});
+            }
+        });
     });
+    $('#all_granted').change(function() {
+        let allGranted = $(this).prop('checked');
+        if (allGranted) {
+            chrome.permissions.request({origins: ['<all_urls>']});
+        } else {
+            chrome.permissions.remove({origins: ['<all_urls>']})
+        }
+        refreshCheckboxEnabledStates(allGranted);
+    });
+
+    function refreshCheckboxEnabledStates(allGranted) {
+        $('#site_granted').prop('disabled', allGranted);
+        $('label[for=site_granted]').toggleClass('disabled', allGranted);
+    }
 
     $(function(){
         siteStatus.then(status => {
-            if (status.isAllGranted) {
-                $('#all_granted').prop('checked', true);
-            } else if (status.isSiteGranted) {
-                $('#site_granted').prop('checked', true);
-            } else {
-                $('#not_granted').prop('checked', true);
+            if (Permission.isMapsSite(status.tabUrl)) {
+                $(document.body).addClass('disable-options');
+                $('#permissionExplanation').text(
+                    'ScrollMaps is enabled on this Google Maps page.');
+                return;
+            }
+            if (status.tabUrl.indexOf('chrome://') === 0) {
+                $(document.body).addClass('disable-options');
+                $('#permissionExplanation').text(
+                    'ScrollMaps cannot be enabled on chrome:// pages');
+                return;
+            }
+            let host = new URL(status.tabUrl).host;
+            if (REQUIRED_PERMISSION_ORIGINS.includes(host)) {
+                $(document.body).addClass('disable-options');
+                $('#permissionExplanation').text(
+                    `ScrollMaps is enabled on ${host}`);
+                return;
             }
 
-            let host = new URL(status.tabUrl).host;
             $('label[for=site_granted] .PMradio_smalltext')
-                .text(`Allow ScrollMaps to access ${host}`);
+                .text(`Enable ScrollMaps on ${host} without having to click on the extension icon`);
+
+            $('#all_granted').prop('checked', status.isAllGranted);
+            $('#site_granted').prop('checked', status.isSiteGranted);
+            refreshCheckboxEnabledStates(status.isAllGranted);
         });
     });
 })();

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -55,10 +55,11 @@
                     'ScrollMaps is enabled on this Google Maps page.');
                 return;
             }
-            if (status.tabUrl.indexOf('chrome://') === 0) {
+            let protocol = new URL(status.tabUrl).protocol;
+            if (protocol === 'chrome:' || protocol === 'chrome-extension:') {
                 $(document.body).addClass('disable-options');
                 $('#permissionExplanation').text(
-                    'ScrollMaps cannot be enabled on chrome:// pages');
+                    `ScrollMaps cannot be enabled on ${protocol}// pages`);
                 return;
             }
             let host = new URL(status.tabUrl).host;

--- a/src/pref.js
+++ b/src/pref.js
@@ -66,7 +66,13 @@ function pref(label){
 
     $(window).bind('preferenceChanged', function(event, pair) {
         Extension.forAllTabs(function (tab) {
-            Message.tab.sendMessage(tab, 'preferenceChanged', pair);
+            Message.tab.sendMessage(tab, 'preferenceChanged', pair, (result) => {
+                let error = chrome.runtime.lastError;
+                let errorMessage = error ? error.message : undefined;
+                if (errorMessage && errorMessage.indexOf('Receiving end does not exist') === -1) {
+                    console.warn(error);
+                }
+            });
         });
     });
 

--- a/src/prefmaker.js
+++ b/src/prefmaker.js
@@ -1,12 +1,38 @@
 /*global $ Pref pref */
 
-/**
-
-  Create views or widgets to toggle certain preference values.
-
-**/
+/** Create views or widgets to toggle certain preference values. */
 
 var PrefMaker = new (function _PrefMaker(){
+
+    this.makePermissionCheckbox = function(key, origin, label, secondLine) {
+        if(typeof secondLine == 'string'){
+            label = createTwoLineBox(label, secondLine);
+        }
+        var div = $('<div class="PMcheckbox"></div>');
+        var box = $('<input id="PMcheckbox_' + key + '" type="checkbox" />');
+        label = $('<label for="PMcheckbox_' + key + '">' + label + '</label>');
+        div.append(box).append(label);
+        box.click(updateOption);
+        label.click(updateOption);
+        updateView();
+
+        var prefChange = false;
+        function updateOption(){
+            if (box.prop('checked')) {
+                chrome.permissions.request({origins: [origin]});
+            } else {
+                chrome.permissions.remove({origins: [origin]});
+            }
+        }
+        async function updateView(){
+            let permission = await Permission.getPermissions([origin]);
+            box.attr('checked', permission);
+        }
+        chrome.permissions.onAdded.addListener(updateView);
+        chrome.permissions.onRemoved.addListener(updateView);
+
+        return div;
+    };
 
     this.makeBooleanCheckbox = function(key, label, secondLine) {
         if(typeof secondLine == 'string'){


### PR DESCRIPTION
With this patch ScrollMaps will install only with permissions to Google Maps domains, and all other sites will be optional. This means that any website using Google Maps API (which includes most uses of Google Maps outside of maps.google.com) will need the user's permission before ScrollMaps can work. This is done to protect the privacy of our users and reduce our surface for security exploits.

This means that on a site using Google Maps API, the user will have to click on the ScrollMaps extension icon on the right of the address bar in order to active it. A green checkmark will then appear to indicate that ScrollMaps is loaded. Clicking on the icon again will open a dialog which the user can give permission to always run on the current domain, or always run on all sites.